### PR TITLE
Add consistent numeric format to GUI and CLI results summaries

### DIFF
--- a/InstallerFiles/FilesToInstall/AppData/Html/TestResult.cshtml
+++ b/InstallerFiles/FilesToInstall/AppData/Html/TestResult.cshtml
@@ -78,7 +78,7 @@
             </tr>
             <tr>
                 <td>Threads:</td>
-                <td>@result.ThreadCount</td>
+                <td>@result.ThreadCount.ToString("n0")</td>
             </tr>
             <tr>
                 <td>Total Time:</td>

--- a/WebSurge.Core/ResultsParser.cs
+++ b/WebSurge.Core/ResultsParser.cs
@@ -48,9 +48,9 @@ namespace WebSurge
             sb.AppendLine("Total Requests: " + result.TotalRequests.ToString("n0"));
 
             if (threads > 0)
-                sb.AppendLine("       Threads: " + result.ThreadCount);
+                sb.AppendLine("       Threads: " + result.ThreadCount.ToString("n0"));
 
-            sb.AppendLine("        Failed: " + result.FailedRequests);
+            sb.AppendLine("        Failed: " + result.FailedRequests.ToString("n0"));
 
             if (result.TimeTakenSecs > 0)
             {


### PR DESCRIPTION
Add consistent numeric format specifier to `Threads` and `Failed` request counts on the CLI results summary output.

Before

![websurgecli-results-before](https://cloud.githubusercontent.com/assets/2045274/19412891/6cdd4290-9317-11e6-8c22-60828dbd6da0.png)

After

![websurgecli-results-after](https://cloud.githubusercontent.com/assets/2045274/19412896/724c6242-9317-11e6-8fe1-666a5c86c8f9.png)

Add consistent numeric format specifier to `Threads` on the GUI results view.

![image](https://cloud.githubusercontent.com/assets/2045274/19413431/878df3ca-9324-11e6-9c39-8bf84dac1770.png)
