### PR TITLE
Add missing info to CLI help

### DIFF
--- a/WebSurgeCli/CommandLineOptions.cs
+++ b/WebSurgeCli/CommandLineOptions.cs
@@ -60,8 +60,9 @@ Commands:
 Value Options:
 --------------
 -s          Number of seconds to run the test (10)
+-w          Number of seconds used for warmup (0)
 -t          Number of simultaneous threads to run (2)
--d          Delay in milliseconds after each request
+-d          Delay in milliseconds after each request (0)
                1-n  Milliseconds of delay between requests
                0   No delay, but give up cpu time slice
                -1   No delay, no time slice (very high cpu usage)

--- a/WebSurgeCli/CommandLineOptions.cs
+++ b/WebSurgeCli/CommandLineOptions.cs
@@ -46,7 +46,7 @@ namespace WebSurge.Cli
             sb.AppendLine("West Wind WebSurge v" + Program.GetVersion());            
 
             string options = @"------------------------
-usage:   WebSurgeCli <SessionFile|Url> -sXX -tXX -dXX -r -yX
+usage:   WebSurgeCli <SessionFile|Url> -sXX -wXX -tXX -dXX -r -yX
 
 Parameters:
 -----------


### PR DESCRIPTION
Adds the existing -w value option to the CLI help display. Also add default value for -d value option.

![image](https://cloud.githubusercontent.com/assets/2045274/19412913/ec2546e2-9317-11e6-9c14-29b315de3ec4.png)
