### PR TITLE
SuccessRequests is now populated in JSON output

### DIFF
--- a/WebSurge.Core/ResultsParser.cs
+++ b/WebSurge.Core/ResultsParser.cs
@@ -31,6 +31,7 @@ namespace WebSurge
                 ThreadCount = threads,
                 TimeTakenSecs = totalTimeSecs,
                 FailedRequests = results.Count(req => req.IsError),
+                SuccessRequests = results.Count(req => !req.IsError),
                 RequestsPerSecond = ((decimal) results.Count/(decimal) totalTimeSecs),
                 AvgRequestTimeMs = (decimal) results.Average(req => req.TimeTakenMs),
                 MinRequestTimeMs = results.Min(req => req.TimeTakenMs),


### PR DESCRIPTION
When using JSON output, the SuccessRequests property of the header section would always read 0.  Now it behaves like the other properties and displays the correct number.