### PR TITLE
Added outputfile parameter and fixed seconds bug

### DIFF
--- a/WebSurge.Core/ResultsParser.cs
+++ b/WebSurge.Core/ResultsParser.cs
@@ -34,7 +34,12 @@ namespace WebSurge
                 RequestsPerSecond = ((decimal) results.Count/(decimal) totalTimeSecs),
                 AvgRequestTimeMs = (decimal) results.Average(req => req.TimeTakenMs),
                 MinRequestTimeMs = results.Min(req => req.TimeTakenMs),
-                MaxRequestTimeMs = results.Max(req => req.TimeTakenMs)
+                MaxRequestTimeMs = results.Max(req => req.TimeTakenMs),
+                ErrorMessages = results.GroupBy(x => x.ErrorMessage).Where(g => g.Key != null).Select(g => new ErrorMessage()
+                {
+                    Message = g.Key,
+                    Count = g.Count()
+                })
             };
 
             return res;
@@ -108,21 +113,31 @@ namespace WebSurge
 
             var urls = resultData
                 .GroupBy(res => res.HttpVerb +  " " + res.Url + (string.IsNullOrEmpty(res.Name) ? "" : " • " + res.Name), rs => rs, (key, uls) =>
-                    new UrlSummary()
+                {
+                    // Prevent multiple enumerations
+                    var results = uls as IList<HttpRequestData> ?? uls.ToList();
+                    
+                    return new UrlSummary()
                     {
-                        Url = key,                        
+                        Url = key,
                         Results = new TestResult()
                         {
                             TimeTakenSecs = totalTimeTakenSecs,
-                            TotalRequests = uls.Count(),
-                            FailedRequests = uls.Count(u => u.IsError),
-                            SuccessRequests = uls.Count(u => !u.IsError),
-                            RequestsPerSecond = ((decimal) uls.Count()/(decimal) totalTimeTakenSecs),
-                            MinRequestTimeMs   = uls.Min( u=> u.TimeTakenMs),
-                            MaxRequestTimeMs = uls.Max(u => u.TimeTakenMs),
-                            AvgRequestTimeMs = (decimal) uls.Average(u=> u.TimeTakenMs),                            
+                            TotalRequests = results.Count(),
+                            FailedRequests = results.Count(u => u.IsError),
+                            SuccessRequests = results.Count(u => !u.IsError),
+                            RequestsPerSecond = ((decimal) results.Count() / (decimal) totalTimeTakenSecs),
+                            MinRequestTimeMs = results.Min(u => u.TimeTakenMs),
+                            MaxRequestTimeMs = results.Max(u => u.TimeTakenMs),
+                            AvgRequestTimeMs = (decimal) results.Average(u => u.TimeTakenMs),
+                            ErrorMessages = results.GroupBy(x => x.ErrorMessage).Where(g => g.Key != null).Select(g => new ErrorMessage()
+                            {
+                                Message = g.Key,
+                                Count = g.Count()
+                            })
                         }
-                    });
+                    };
+                });
 
 
 
@@ -130,9 +145,12 @@ namespace WebSurge
         }
 
         public TestResultView GetResultReport(IEnumerable<HttpRequestData> resultData,
-            int totalTimeTaken,
+            int totalTimeTakenMs,
             int threadCount)
         {
+            // Convert milliseconds to seconds
+            var totalTimeTaken = totalTimeTakenMs / 1000;
+
             var urlSummary = UrlSummary(resultData, totalTimeTaken);
             var testResult = ParseResults(resultData, totalTimeTaken, threadCount);
 
@@ -180,7 +198,15 @@ namespace WebSurge
         public decimal AvgRequestTimeMs { get; set; }
         public decimal MinRequestTimeMs { get; set; }
         public decimal MaxRequestTimeMs { get; set; }
-        public int TimeTakenSecs { get; set; }        
+        public int TimeTakenSecs { get; set; }
+        public IEnumerable<ErrorMessage> ErrorMessages { get; set; }
+    }
+
+    public class ErrorMessage
+    {
+        public string Message { get; set; }
+
+        public int Count { get; set; }
     }
 
     public class RequestsPerSecondResult

--- a/WebSurge.Core/StressTester.cs
+++ b/WebSurge.Core/StressTester.cs
@@ -364,7 +364,6 @@ namespace WebSurge
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Exception: " + ex.Message);
                 result.IsError = true;
                 result.ErrorMessage = "CheckSite Error: " + ex.GetBaseException().Message;
 

--- a/WebSurge.Tests/ResultsParserTests.cs
+++ b/WebSurge.Tests/ResultsParserTests.cs
@@ -12,6 +12,72 @@ namespace SimpleStressTester.Tests
     [TestClass]
     public class ResultsParserTests
     {
+
+        [TestMethod]
+        public void ResultsReportTimeTakenTest()
+        {
+            var time = DateTime.UtcNow;
+
+            var requests = new List<HttpRequestData>()
+            {
+                new HttpRequestData()
+                {
+                    Timestamp = time,
+                    TimeTakenMs = 10
+                },
+                new HttpRequestData()
+                {
+                    Timestamp = time.AddMilliseconds(20),
+                    TimeTakenMs = 15
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(220),
+                    TimeTakenMs = 15
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(1020),
+                    TimeTakenMs = 20
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(1050),
+                    TimeTakenMs = 20
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(1200),
+                    TimeTakenMs = 20
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(3020),
+                    TimeTakenMs = 20
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(3050),
+                    TimeTakenMs = 20
+                },
+                new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(3200),
+                    TimeTakenMs = 20
+                },  new HttpRequestData
+                {
+                    Timestamp = time.AddMilliseconds(3500),
+                    TimeTakenMs = 50
+                }
+            };
+            var timeTakenMs = 30000;
+
+            var parser = new ResultsParser();
+            var results = parser.GetResultReport(requests, timeTakenMs, 10);
+
+            Assert.AreEqual(timeTakenMs / 1000, results.TestResult.TimeTakenSecs);
+        }
+
         [TestMethod]
         public void RequestPerSecondListTest()
         {

--- a/WebSurgeCli/CommandLineOptions.cs
+++ b/WebSurgeCli/CommandLineOptions.cs
@@ -37,6 +37,9 @@ namespace WebSurge.Cli
         [Option("json", HelpText="Generates only JSON output.")]
         public bool Json {get; set;}
 
+        [Option("outputFile", HelpText = "Saves the output to a file")]
+        public string OutputFile { get; set; }
+
         [HelpOption]
         public string GetUsage()
         {
@@ -46,7 +49,7 @@ namespace WebSurge.Cli
             sb.AppendLine("West Wind WebSurge v" + Program.GetVersion());            
 
             string options = @"------------------------
-usage:   WebSurgeCli <SessionFile|Url> -sXX -wXX -tXX -dXX -r -yX
+usage:   WebSurgeCli <SessionFile|Url> -sXX -wXX -tXX -dXX -r -yX --outputFile ""output.json""
 
 Parameters:
 -----------
@@ -77,6 +80,7 @@ Switches:
 Output:
 -------
 --json       Return results as JSON
+--outputFile Save the output to a filename
 
 Examples:
 ---------

--- a/WebSurgeCli/Program.cs
+++ b/WebSurgeCli/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -96,6 +97,10 @@ namespace WebSurge.Cli
                 string json = JsonSerializationUtils.Serialize(result, formatJsonOutput: true);
                 Console.WriteLine(json);
                 Console.ForegroundColor = origColor;
+                if (options.OutputFile != null)
+                {
+                    File.WriteAllText(options.OutputFile, json);
+                }
                 return;
             }
 
@@ -118,6 +123,11 @@ namespace WebSurge.Cli
 
             Console.WriteLine();
             Console.WriteLine(resultText);
+
+            if (options.OutputFile != null)
+            {
+                File.WriteAllText(options.OutputFile, resultText);
+            }
 
             Console.ForegroundColor = origColor;
         }


### PR DESCRIPTION
- Added a new **outputFile** commandline option which allows you to save the output to a file.
- Fixed a bug with the TimeTakenSecs property in the output, it was displaying milliseconds rather than seconds.
- Added an ErrorMessages property to the output JSON format.