### PR TITLE
Add 90th, 95th and 99th percentiles to results

### DIFF
--- a/WebSurge.Core/PercentileExtensions.cs
+++ b/WebSurge.Core/PercentileExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebSurge
+{
+    public static class PercentileExtensions
+    {
+        public static decimal Percentile(this IEnumerable<decimal> sequence, decimal percentile)
+        {
+            var orderedSequence = sequence.OrderBy(x => x).ToList();
+            var count = orderedSequence.Count;
+            var rank = (count - 1) * percentile + 1;
+
+            if (rank == 1)
+            {
+                return orderedSequence[0];
+            }
+
+            if (rank == count)
+            {
+                return orderedSequence[count - 1];
+            }
+
+            var integerPortion = (int)rank;
+            var fractionalPortion = rank - integerPortion;
+            return orderedSequence[integerPortion - 1] + fractionalPortion * (orderedSequence[integerPortion] - orderedSequence[integerPortion - 1]);
+        }
+
+        public static decimal Percentile<TSource>(this IEnumerable<TSource> sequence, Func<TSource, decimal> selector, decimal percentile)
+        {
+            return sequence.Select(selector).Percentile(percentile);
+        }
+    }
+}

--- a/WebSurge.Core/ResultsParser.cs
+++ b/WebSurge.Core/ResultsParser.cs
@@ -36,6 +36,9 @@ namespace WebSurge
                 AvgRequestTimeMs = (decimal) results.Average(req => req.TimeTakenMs),
                 MinRequestTimeMs = results.Min(req => req.TimeTakenMs),
                 MaxRequestTimeMs = results.Max(req => req.TimeTakenMs),
+                Percentile90 = results.Percentile(req => req.TimeTakenMs, 0.9M),
+                Percentile95 = results.Percentile(req => req.TimeTakenMs, 0.95M),
+                Percentile99 = results.Percentile(req => req.TimeTakenMs, 0.99M),
                 ErrorMessages = results
                                     .GroupBy(x => x.ErrorMessage)
                                     .Where(g => g.Key != null)
@@ -74,6 +77,9 @@ namespace WebSurge
                 sb.AppendLine(string.Format("      Avg Time: {0:n2} ms", result.AvgRequestTimeMs));
                 sb.AppendLine(string.Format("      Min Time: {0:n2} ms", result.MinRequestTimeMs));
                 sb.AppendLine(string.Format("      Max Time: {0:n2} ms", result.MaxRequestTimeMs));
+                sb.AppendLine(string.Format("      90th Percentile: {0:n2} ms", result.Percentile90));
+                sb.AppendLine(string.Format("      95th Percentile: {0:n2} ms", result.Percentile95));
+                sb.AppendLine(string.Format("      99th Percentile: {0:n2} ms", result.Percentile99));
             }
 
             return sb.ToString();
@@ -136,6 +142,9 @@ namespace WebSurge
                                 MinRequestTimeMs = results.Min(u => u.TimeTakenMs),
                                 MaxRequestTimeMs = results.Max(u => u.TimeTakenMs),
                                 AvgRequestTimeMs = (decimal) results.Average(u => u.TimeTakenMs),
+                                Percentile90 = results.Percentile(req => req.TimeTakenMs, 0.9M),
+                                Percentile95 = results.Percentile(req => req.TimeTakenMs, 0.95M),
+                                Percentile99 = results.Percentile(req => req.TimeTakenMs, 0.99M),
                                 ErrorMessages = results
                                     .GroupBy(x => x.ErrorMessage)
                                     .Where(g => g.Key != null)
@@ -207,6 +216,9 @@ namespace WebSurge
         public decimal AvgRequestTimeMs { get; set; }
         public decimal MinRequestTimeMs { get; set; }
         public decimal MaxRequestTimeMs { get; set; }
+        public decimal Percentile90 { get; set; }
+        public decimal Percentile95 { get; set; }
+        public decimal Percentile99 { get; set; }
         public int TimeTakenSecs { get; set; }
         public IEnumerable<ErrorMessage> ErrorMessages { get; set; }
     }

--- a/WebSurge.Core/WebSurge.Core.csproj
+++ b/WebSurge.Core/WebSurge.Core.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Extensibility\IWebSurgeExtensibility.cs" />
     <Compile Include="Extensibility\PluginLoader.cs" />
     <Compile Include="Extensibility\WebSurgeExtensibilityBase.cs" />
+    <Compile Include="PercentileExtensions.cs" />
     <Compile Include="Support\SiteValidator.cs" />
     <Compile Include="Support\ApplicationUpdater.cs" />
     <Compile Include="Configuration\CheckForUpdates.cs" />

--- a/WebSurge.Tests/PercentileExtensionsTests.cs
+++ b/WebSurge.Tests/PercentileExtensionsTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebSurge;
+
+namespace SimpleStressTester.Tests
+{
+    [TestClass]
+    public class PercentileExtensionsTests
+    {
+        [TestMethod]
+        public void TestPercentile()
+        {
+            var sequence = new[] {35m, 40m, 20m, 50m, 15m};
+
+            Assert.AreEqual(46m, sequence.Percentile(0.9m));
+            Assert.AreEqual(48m, sequence.Percentile(0.95m));
+            Assert.AreEqual(49.6m, sequence.Percentile(0.99m));
+            Assert.AreEqual(50m, sequence.Percentile(1m));
+        }
+    }
+}

--- a/WebSurge.Tests/WebSurge.Tests.csproj
+++ b/WebSurge.Tests/WebSurge.Tests.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <Compile Include="FiddlerParserTests.cs" />
     <Compile Include="MruListTests.cs" />
+    <Compile Include="PercentileExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestEncoding.cs" />
     <Compile Include="ResultsParserTests.cs" />


### PR DESCRIPTION
In load tests, percentiles are often more valuable than the average. 

Your average could be skewed positively or negatively because of a very high or very low response time. But 90% of the responses might tell a different story.

For example, the average could be 14000ms because of a minority of extremely slow responses, while 90% or more of the responses could have been under 1000ms. This makes the percentiles a more useful indicator of how responsive your application is.

This PR adds the 90th, 95th and 99th percentiles to the results.

I didn't find the templates for the results in the GUI version, but all I needed to add was this:

```
<tr>
    <td>90th Percentile:</td>
    <td>@result.Percentile90.ToString("n2") ms</td>
</tr>
<tr>
    <td>95th Percentile</td>
    <td>@result.Percentile95.ToString("n2") ms</td>
</tr>
<tr>
    <td>99th Percentile</td>
    <td>@result.Percentile99.ToString("n2") ms</td>
</tr>
```

and this:
```
<tr>
    <td style="width: 125px;">
    </td>
    <td style="width: 125px;">
    </td>

    <td>
        90&percnt;ile: @(urlItem.Results.Percentile90.ToString("n0"))ms &nbsp;&nbsp;
    </td>
    <td>
        95&percnt;ile: @(urlItem.Results.Percentile95.ToString("n0"))ms &nbsp;&nbsp;
    </td>
    <td>
        99&percnt;ile: @(urlItem.Results.Percentile99.ToString("n0"))ms &nbsp;&nbsp;
    </td>
</tr>
```

This results in this:

![capture](https://user-images.githubusercontent.com/3483719/44416311-e0225000-a572-11e8-856c-f2c66f3be559.PNG)